### PR TITLE
fix(cancel) ensure no holes in slot after cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Tests
 =====
 
 Tests are in the `spec` folder and can be executed using the
-[busted test framework](http://olivine-labs.github.io/busted/). Just run
+[busted test framework](https://lunarmodules.github.io/busted/). Just run
 `"busted"` from the repo.
 
 Besides that `luacheck` is configured for linting, just run `"luacheck ."` from

--- a/README.md
+++ b/README.md
@@ -65,7 +65,12 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/).
 - test the newly created rock:<br/>
   `luarocks install timerwheel`
 
-## 1.0.0 unreleased
+## 1.0.x unreleased
+
+- Fix: if a slot was modified (by cancelling) a hole might appear in the table
+  causing an xpcall with `nil` instead of the callback function
+
+## 1.0.0 released 22-Aug-2022
 
 - Bump to 1.0 since API is stable
 - Fix: added a newline when writing errors to `stderr`, since `io.stderr:write()`

--- a/spec/timerwheel_spec.lua
+++ b/spec/timerwheel_spec.lua
@@ -395,6 +395,27 @@ describe("Timerwheel", function()
     end)
 
 
+    it("removes timers, leaving holes in the slot", function()
+      local called = {}
+      local id1 = wheel:set(0.5, function(arg) called[#called+1] = arg end, "id1")
+      local _   = wheel:set(0.5, function(arg) called[#called+1] = arg end, "id2")
+      local id3 = wheel:set(0.5, function(arg) called[#called+1] = arg end, "id3")
+      local _   = wheel:set(0.5, function(arg) called[#called+1] = arg end, "id4")
+      local id5 = wheel:set(0.5, function(arg) called[#called+1] = arg end, "id5")
+      assert.is.equal(5, wheel:count())
+      assert.is.True(wheel:cancel(id1))
+      assert.is.True(wheel:cancel(id3))
+      assert.is.True(wheel:cancel(id5))
+
+      set_time(1)
+      wheel:step()
+
+      table.sort(called)
+      assert.is.equal(2, #called)
+      assert.is.same({ "id2", "id4" }, called)
+    end)
+
+
     it("callback and args gets GC'ed after cancelling", function()
       local count = 0
       local cb = function() count = count + 1 end

--- a/src/timerwheel/init.lua
+++ b/src/timerwheel/init.lua
@@ -43,19 +43,15 @@ local _M = {}
 
 
 --- Creates a new timer wheel.
--- The options are:
---
---  - `precision` (optional) precision of the timer wheel in seconds (slot size),
--- defaults to 0.050
---  - `ringsize` (optional) number of slots in each ring, defaults to 72000 (1
--- hour span, based on default `precision`)
---  - `now` (optional) a function returning the curent time in seconds. Defaults
--- to `luasocket.gettime` or `ngx.now` if available.
---  - `err_handler` (optional) a function to use as error handler in a `xpcall` when
--- executing the callback. The default will send the stacktrace on `stderr`.
---
--- @param opts the options table
--- @return the timerwheel object
+-- @tparam table opts the options table
+-- @tparam[opt=0.050] number opts.precision the precision of the timer wheel in seconds (slot size),
+-- @tparam[opt] int opts.ringsize number of slots in each ring, defaults to 72000 (1
+-- hour span, with `precision == 0.050`)
+-- @tparam[opt] function opts.now a function returning the curent time in seconds. Defaults
+-- to `ngx.now` or `luasocket.gettime` if available.
+-- @tparam[opt] function opts.err_handler a function to use as error handler in an `xpcall` when
+-- executing the callback. The default will write the stacktrace to `stderr`.
+-- @treturn wheel the timerwheel object
 function _M.new(opts)
   assert(opts ~= _M, "new should not be called with colon ':' notation")
 
@@ -147,17 +143,17 @@ function _M.new(opts)
   end
 
   --- Gets the number of timers.
-  -- @return number of timers
+  -- @treturn int number of timers
   function wheel:count()
     return count
   end
 
   --- Sets a timer.
-  -- @param expire_in in how many seconds should the timer expire
-  -- @param cb callback function to execute upon expiring (NOTE: the
+  -- @tparam number expire_in in how many seconds should the timer expire
+  -- @tparam function cb callback function to execute upon expiring (NOTE: the
   -- callback will run within an `xpcall`)
   -- @param arg parameter to be passed to `cb` when executing
-  -- @return id
+  -- @treturn int the id of the newly set timer
   -- @usage
   -- local cb = function(arg)
   --   print("timer executed with: ", arg)  --> "timer executed with: hello world"
@@ -219,8 +215,8 @@ function _M.new(opts)
   end
 
   --- Cancels a timer.
-  -- @param id the timer id to cancel
-  -- @return `true` if cancelled, `false` if not found
+  -- @tparam int id the timer id to cancel
+  -- @treturn boolean `true` if cancelled, `false` if not found
   function wheel:cancel(id)
     local slot = id_list[id]
     if slot then
@@ -243,9 +239,9 @@ function _M.new(opts)
 
   --- Looks up the next expiring timer.
   -- Note: traverses the wheel, O(n) operation!
-  -- @param max_ahead (optional) maximum time (in seconds)
+  -- @tparam[opt] number max_ahead maximum time (in seconds)
   -- to look ahead
-  -- @return number of seconds until next timer expires (can be negative), or
+  -- @treturn number number of seconds until next timer expires (can be negative), or
   -- 'nil' if there is no timer from now to `max_ahead`
   -- @usage
   -- local t = wheel:peek(10)

--- a/src/timerwheel/init.lua
+++ b/src/timerwheel/init.lua
@@ -229,7 +229,9 @@ function _M.new(opts)
       slot.ids[id] = nil
       slot.arg[id] = nil
       local n = slot.n
-      slot[idx] = slot[n]
+      local moved_id = slot[n]
+      slot[idx] = moved_id
+      slot[moved_id] = idx
       slot[n] = nil
       slot.n = n - 1
       id_list[id] = nil


### PR DESCRIPTION
if a slot was modified (by cancelling) a hole might appear in the table
causing an xpcall with `nil` instead of the callback function